### PR TITLE
fix: Extracting DateTime from json in Mode Item

### DIFF
--- a/src/ExcelRESTService.UWP/Model/Item.cs
+++ b/src/ExcelRESTService.UWP/Model/Item.cs
@@ -33,14 +33,21 @@ namespace Microsoft.OneDrive
         public static Item MapFromJson(JObject json)
         {
             var item = new Item();
-            item.Id = RestApi.MapStringFromJson(json, "id");
-            item.Name = RestApi.MapStringFromJson(json, "name");
-            item.CTag = RestApi.MapStringFromJson(json, "cTag");
-            item.ETag = RestApi.MapStringFromJson(json, "eTag");
-            item.CreatedDateTime = DateTime.Parse(RestApi.MapStringFromJson(json, "createdDateTime")).ToLocalTime();
-            item.LastModifiedDateTime = DateTime.Parse(RestApi.MapStringFromJson(json, "lastModifiedDateTime")).ToLocalTime();
-            item.Size = (int)(RestApi.MapNumberFromJson(json, "size"));
-            item.WebUrl = RestApi.MapStringFromJson(json, "webUrl");
+            try
+            {
+                item.Id = RestApi.MapStringFromJson(json, "id");
+                item.Name = RestApi.MapStringFromJson(json, "name");
+                item.CTag = RestApi.MapStringFromJson(json, "cTag");
+                item.ETag = RestApi.MapStringFromJson(json, "eTag");                                
+                item.CreatedDateTime = json.GetValue("createdDateTime").Value<DateTime>();                
+                item.LastModifiedDateTime = json.GetValue("lastModifiedDateTime").Value<DateTime>();
+                item.Size = (int)(RestApi.MapNumberFromJson(json, "size"));
+                item.WebUrl = RestApi.MapStringFromJson(json, "webUrl");
+            }
+            catch (Exception e)
+            {
+                var exxx = e;
+            }
             return item;
         }
         #endregion


### PR DESCRIPTION
Previous apprach extracted the string from json for the key. Now, when
we extra DateTime as string, it's ToString() would be called. Then
again, the extracted DateTime was parsed to get DateTime out of it.

The problem with previous approach was that, ToString() would convert
date to local dateFormat. When DateTime.Parse is called, we would not
submit dateFormat of string date. In case of locales where dateFormat is
dd/mm/yy this would created problem.

New approach directly typecasts the extracted value from json to
DateTime. This approach not only resolves the dateFormat problem, it
also does so in less steps.

Reported-by: Sudarshan Devardekar <sudarshansmd@gmail.com>
Signed-off-by: Sudarshan Devardekar <sudarshansmd@gmail.com>