### PR TITLE
fix: Extracting DateTime from json in Model Item

### DIFF
--- a/src/ExcelRESTService.UWP/Model/Item.cs
+++ b/src/ExcelRESTService.UWP/Model/Item.cs
@@ -33,14 +33,21 @@ namespace Microsoft.OneDrive
         public static Item MapFromJson(JObject json)
         {
             var item = new Item();
-            item.Id = RestApi.MapStringFromJson(json, "id");
-            item.Name = RestApi.MapStringFromJson(json, "name");
-            item.CTag = RestApi.MapStringFromJson(json, "cTag");
-            item.ETag = RestApi.MapStringFromJson(json, "eTag");
-            item.CreatedDateTime = DateTime.Parse(RestApi.MapStringFromJson(json, "createdDateTime")).ToLocalTime();
-            item.LastModifiedDateTime = DateTime.Parse(RestApi.MapStringFromJson(json, "lastModifiedDateTime")).ToLocalTime();
-            item.Size = (int)(RestApi.MapNumberFromJson(json, "size"));
-            item.WebUrl = RestApi.MapStringFromJson(json, "webUrl");
+            try
+            {
+                item.Id = RestApi.MapStringFromJson(json, "id");
+                item.Name = RestApi.MapStringFromJson(json, "name");
+                item.CTag = RestApi.MapStringFromJson(json, "cTag");
+                item.ETag = RestApi.MapStringFromJson(json, "eTag");                                
+                item.CreatedDateTime = json.GetValue("createdDateTime").Value<DateTime>();                
+                item.LastModifiedDateTime = json.GetValue("lastModifiedDateTime").Value<DateTime>();
+                item.Size = (int)(RestApi.MapNumberFromJson(json, "size"));
+                item.WebUrl = RestApi.MapStringFromJson(json, "webUrl");
+            }
+            catch (Exception e)
+            {
+                var exxx = e;
+            }
             return item;
         }
         #endregion

--- a/src/ExcelRESTService.UWP/Model/Item.cs
+++ b/src/ExcelRESTService.UWP/Model/Item.cs
@@ -33,21 +33,14 @@ namespace Microsoft.OneDrive
         public static Item MapFromJson(JObject json)
         {
             var item = new Item();
-            try
-            {
-                item.Id = RestApi.MapStringFromJson(json, "id");
-                item.Name = RestApi.MapStringFromJson(json, "name");
-                item.CTag = RestApi.MapStringFromJson(json, "cTag");
-                item.ETag = RestApi.MapStringFromJson(json, "eTag");                                
-                item.CreatedDateTime = json.GetValue("createdDateTime").Value<DateTime>();                
-                item.LastModifiedDateTime = json.GetValue("lastModifiedDateTime").Value<DateTime>();
-                item.Size = (int)(RestApi.MapNumberFromJson(json, "size"));
-                item.WebUrl = RestApi.MapStringFromJson(json, "webUrl");
-            }
-            catch (Exception e)
-            {
-                var exxx = e;
-            }
+            item.Id = RestApi.MapStringFromJson(json, "id");
+            item.Name = RestApi.MapStringFromJson(json, "name");
+            item.CTag = RestApi.MapStringFromJson(json, "cTag");
+            item.ETag = RestApi.MapStringFromJson(json, "eTag");
+            item.CreatedDateTime = json.GetValue("createdDateTime").Value<DateTime>();
+            item.LastModifiedDateTime = json.GetValue("lastModifiedDateTime").Value<DateTime>();
+            item.Size = (int)(RestApi.MapNumberFromJson(json, "size"));
+            item.WebUrl = RestApi.MapStringFromJson(json, "webUrl");
             return item;
         }
         #endregion


### PR DESCRIPTION
Previous approach to get DateTime from json used to extract the string from json using its key, and then prase the string using DateTime.Parse(). When DateTime is extracted from json as string, the DateTime is converted to string by calling ToString() on DateTime. When ToString() is called on DateTime, it converts DateTime to local string date format.

The problem with previous apprach was that, DateTime.ToString() would
convert the date to locale dateFormat. When DateTime.Parse() is again
called on string date, dateFormat of string is not provided. This
creates problem in parsing dates with certain dateFormat viz. dd/mm/yy.

New approach directly typecasts the extracted value from json to
DateTime. This approach not only resolves the dateFormat problem, but it
also does so in less steps.

Reported-by: Sudarshan Devardekar <sudarshansmd@gmail.com>
Signed-off-by: Sudarshan Devardekar <sudarshansmd@gmail.com>